### PR TITLE
Refactor

### DIFF
--- a/.astylerc
+++ b/.astylerc
@@ -1,0 +1,42 @@
+# Don't create backup files, let git handle it
+suffix=none
+
+# K&R style
+style=google
+
+# 4 spaces, convert tabs to spaces
+indent=spaces=4
+convert-tabs
+
+# Indent
+indent-switches
+indent-classes
+indent-preproc-block
+indent-preproc-define
+
+# Brackets
+add-brackets
+
+# Remove spaces in and around parentheses
+unpad-paren
+
+# Insert a space after if, while, for, and around operators
+pad-header
+pad-oper
+
+# Pointer/reference operators go next to the name (on the right)
+align-pointer=name
+align-reference=name
+
+# Attach { for classes and namespaces
+attach-namespaces
+attach-classes
+
+# Extend longer lines, define maximum 120 value. This results in aligned code,
+# otherwise the lines are broken and not consistent 
+max-continuation-indent=120
+max-code-length=120
+
+# Breaks
+break-after-logical
+break-blocks=all

--- a/LCD.cpp
+++ b/LCD.cpp
@@ -220,9 +220,6 @@ uint8_t LCD::getAddress(uint8_t column, uint8_t row) {
                     return -1;
             }
 
-        case LCD16x2:
-        case LCD20x2:
-        case LCD40x2:
         default:
             return 0x80 + (row * 0x40) + column;
     }
@@ -235,7 +232,9 @@ uint8_t LCD::columns() {
         case LCD40x2:
             return 20;
 
-        case LCD16x2:
+        case LCD8x2:
+            return 8;
+
         default:
             return 16;
     }
@@ -246,36 +245,33 @@ uint8_t LCD::rows() {
         case LCD20x4:
             return 4;
 
-        case LCD16x2:
-        case LCD20x2:
-        case LCD40x2:
         default:
             return 2;
     }
 }
 
 void LCD::writeCommand(uint8_t command) {
-    _rs = 0;
+    _rs.write(0);
     writeByte(command);
 }
 
 void LCD::writeData(uint8_t data) {
-    _rs = 1;
+    _rs.write(1);
     writeByte(data);
 }
 
 void LCD::writeByte(uint8_t value) {
-    _data = value >> 4; // send upper part first
+    _data.write(value >> 4); // send upper part first
     pulseEnable();
-    _data = value;
+    _data.write(value & 0b1111);
     pulseEnable();
 }
 
 void LCD::pulseEnable() {
-    _en = 0;
+    _en.write(0);
     wait_us(1);
-    _en = 1;
+    _en.write(1);
     wait_us(1);
-    _en = 0;
+    _en.write(0);
     wait_us(40);
 }

--- a/LCD.cpp
+++ b/LCD.cpp
@@ -27,12 +27,13 @@
 
 LCD::LCD(PinName rs, PinName en, PinName d4, PinName d5, PinName d6, PinName d7, PinName rw, lcd_type_t type):
     _rs(rs), _en(en), _data(d4, d5, d6, d7), _type(type) {
+
+    _data.write(0);
+
     if (rw != NC) {
         _rw = new DigitalOut(rw);
         _rw->write(1);
     }
-
-    _data.write(0);
 }
 
 LCD::~LCD() {
@@ -273,9 +274,9 @@ void LCD::writeByte(uint8_t value) {
 
 void LCD::pulseEnable() {
     _en.write(0);
-    wait_us(1);
+    wait_us(2);
     _en.write(1);
-    wait_us(1);
+    wait_us(2);
     _en.write(0);
     wait_us(40);
 }

--- a/LCD.cpp
+++ b/LCD.cpp
@@ -28,9 +28,11 @@
 LCD::LCD(PinName rs, PinName en, PinName d4, PinName d5, PinName d6, PinName d7, PinName rw, lcd_type_t type):
     _rs(rs), _en(en), _data(d4, d5, d6, d7), _type(type) {
     if (rw != NC) {
-        _rw = new DigitalInOut(rw);
+        _rw = new DigitalOut(rw);
         _rw->write(1);
     }
+
+    _data.write(0);
 }
 
 LCD::~LCD() {

--- a/LCD.cpp
+++ b/LCD.cpp
@@ -157,6 +157,8 @@ void LCD::display(lcd_mode_t mode) {
             writeCommand(CMD_ENTRY_MODE_SET | _display_mode);
             break;
     }
+
+    ThisThread::sleep_for(3ms);
 }
 
 void LCD::create(uint8_t location, uint8_t charmap[]) {

--- a/LCD.cpp
+++ b/LCD.cpp
@@ -1,6 +1,7 @@
 /* mbed TextLCD Library, for a 4-bit LCD based on HD44780
  * Copyright (c) 2007-2010, sford, http://mbed.org
  * Copyright (c) 2020, sstaub
+ * Copyright (c) 2021, pilotak
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -24,200 +25,258 @@
 #include "LCD.h"
 #include "mbed.h"
 
-LCD::LCD(PinName rs, PinName en, PinName d4, PinName d5, PinName d6, PinName d7, lcd_t type) : reset(rs), enable(en), data(d4, d5, d6, d7) {
-	this->type = type;
+LCD::LCD(PinName rs, PinName en, PinName d4, PinName d5, PinName d6, PinName d7, lcd_type_t type, PinName rw):
+    _rs(rs), _en(en), _data(d4, d5, d6, d7) {
+    _type = type;
 
-	ThisThread::sleep_for(15ms); // Wait 15ms to ensure powered up
+    if (rw != NC) {
+        _rw = new DigitalInOut(rw);
+        _rw->write(1);
+    }
+}
 
-	// send "Display Settings" 3 times (Only top nibble of 0x30 as we've got 4-bit bus)
-	for (int i = 0; i < 3; i++) {
-		writeByte(0x3);
-		ThisThread::sleep_for(2ms); // this command takes 1.64ms, so wait for it
-		}
+LCD::~LCD() {
+    if (_rw) {
+        delete _rw;
+    }
+}
 
-	writeCommand(LCD_4BIT_MODE); // set 4bit mode
-	writeCommand(0x28); // function set 001 BW N F - -
-	writeCommand(0x0C);
-	writeCommand(0x06); // cursor direction and display shift : 0000 01 CD S (CD 0-left, 1-right S(hift) 0-no, 1-yes
+void LCD::init() {
+    _rs.write(0);
+    _en.write(0);
 
-	cls();
-	}
+    if (_rw) {
+        _rw->write(0); // write mode
+    }
 
+    for (auto i = 0; i < 3; i++) {
+        writeByte(0x3);
+        ThisThread::sleep_for(5ms);
+    }
+
+    writeCommand(0x02); // 4-bit interface
+    uint8_t display_function = FN_4BIT_MODE | FN_5x8DOTS;
+
+    if (rows() == 1) {
+        display_function |= FN_1LINE;
+
+    } else if (rows() == 2) {
+        display_function |= FN_2LINE;
+    }
+
+    writeCommand(CMD_FUNCTION_SET | display_function);
+
+    _display_control = CTRL_DISPLAY_OFF | CTRL_CURSOR_OFF | CTRL_BLINK_OFF;
+    writeCommand(CMD_DISPLAY_CONTROL | _display_control);
+
+    cls();
+
+    _display_mode = ENTRY_MODE_LEFT | ENTRY_MODE_SHIFT_DECREMENT;
+    writeCommand(CMD_ENTRY_MODE_SET | _display_mode);
+}
 void LCD::character(uint8_t column, uint8_t row, uint8_t c) {
-	int a = address(column, row);
-	writeCommand(a);
-	writeData(c);
-	}
+    uint8_t addr = getAddress(column, row);
+    writeCommand(addr);
+    writeData(c);
+}
 
 void LCD::cls() {
-	writeCommand(0x01); // cls, and set cursor to 0
-	ThisThread::sleep_for(2ms); // this command takes 1.64 ms
-	locate(0, 0);
-	}
+    writeCommand(CMD_CLEAR_DISPLAY);
+    locate(0, 0);
+    ThisThread::sleep_for(3ms); // this command takes a long time!
+}
 
 void LCD::locate(uint8_t column, uint8_t row) {
-	_column = column;
-	_row = row;
-	}
+    _column = column;
+    _row = row;
+}
 
 void LCD::home() {
-	writeCommand(LCD_RETURN_HOME);
-	ThisThread::sleep_for(2ms); // this command takes a long time!
-	}
+    writeCommand(CMD_RETURN_HOME);
+    ThisThread::sleep_for(3ms); // this command takes a long time!
+}
 
-void LCD::display(modes_t mode) {
-	switch(mode) {
-		case DISPLAY_ON :
-			displaycontrol |= LCD_DISPLAY_ON;
-			writeCommand(LCD_DISPLAY_CONTROL | displaycontrol);
-			break;
-		case DISPLAY_OFF:
-			displaycontrol &= ~LCD_DISPLAY_ON;
-			writeCommand(LCD_DISPLAY_CONTROL | displaycontrol);
-			break;
-		case CURSOR_ON:
-			displaycontrol |= LCD_CURSOR_ON;
-			writeCommand(LCD_DISPLAY_CONTROL | displaycontrol);
-			break;
-		case CURSOR_OFF:
-			displaycontrol &= ~LCD_CURSOR_ON;
-			writeCommand(LCD_DISPLAY_CONTROL | displaycontrol);
-			break;
-		case BLINK_ON:
-			displaycontrol |= LCD_BLINK_ON;
-			writeCommand(LCD_DISPLAY_CONTROL | displaycontrol);
-			break;
-		case BLINK_OFF:
-			displaycontrol &= ~LCD_BLINK_ON;
-			writeCommand(LCD_DISPLAY_CONTROL | displaycontrol);
-			break;
-		case SCROLL_LEFT:
-			writeCommand(LCD_CURSOR_SHIFT | LCD_DISPLAY_MOVE | LCD_MOVE_LEFT);
-			break;
-		case SCROLL_RIGHT:
-			writeCommand(LCD_CURSOR_SHIFT | LCD_DISPLAY_MOVE | LCD_MOVE_RIGHT);
-			break;
-		case LEFT_TO_RIGHT:
-			displaymode |= LCD_ENTRY_LEFT;
-			writeCommand(LCD_ENTRY_MODE_SET | displaymode);
-			break;
-		case RIGHT_TO_LEFT:
-			displaymode &= ~LCD_ENTRY_LEFT;
-			writeCommand(LCD_ENTRY_MODE_SET | displaymode);
-			break;
-		case SCROLL_ON:
-			displaymode |= LCD_ENTRY_SHIFT_INCREMENT;
-			writeCommand(LCD_ENTRY_MODE_SET | displaymode);
-			break;
-		case SCROLL_OFF:
-			displaymode &= ~LCD_ENTRY_SHIFT_INCREMENT;
-			writeCommand(LCD_ENTRY_MODE_SET | displaymode);
-			break;
-		}
-	}
+void LCD::display(lcd_mode_t mode) {
+    switch (mode) {
+        case DISPLAY_ON :
+            _display_control |= CTRL_DISPLAY_ON;
+            writeCommand(CMD_DISPLAY_CONTROL | _display_control);
+            break;
+
+        case DISPLAY_OFF:
+            _display_control &= ~CTRL_DISPLAY_ON;
+            writeCommand(CMD_DISPLAY_CONTROL | _display_control);
+            break;
+
+        case CURSOR_ON:
+            _display_control |= CTRL_CURSOR_ON;
+            writeCommand(CMD_DISPLAY_CONTROL | _display_control);
+            break;
+
+        case CURSOR_OFF:
+            _display_control &= ~CTRL_CURSOR_ON;
+            writeCommand(CMD_DISPLAY_CONTROL | _display_control);
+            break;
+
+        case BLINK_ON:
+            _display_control |= CTRL_BLINK_ON;
+            writeCommand(CMD_DISPLAY_CONTROL | _display_control);
+            break;
+
+        case BLINK_OFF:
+            _display_control &= ~CTRL_BLINK_ON;
+            writeCommand(CMD_DISPLAY_CONTROL | _display_control);
+            break;
+
+        case SCROLL_LEFT:
+            writeCommand(CMD_CURSOR_SHIFT | DISPLAY_MOVE | MOVE_LEFT);
+            break;
+
+        case SCROLL_RIGHT:
+            writeCommand(CMD_CURSOR_SHIFT | DISPLAY_MOVE | MOVE_RIGHT);
+            break;
+
+        case LEFT_TO_RIGHT:
+            _display_mode |= ENTRY_MODE_LEFT;
+            writeCommand(CMD_ENTRY_MODE_SET | _display_mode);
+            break;
+
+        case RIGHT_TO_LEFT:
+            _display_mode &= ~ENTRY_MODE_LEFT;
+            writeCommand(CMD_ENTRY_MODE_SET | _display_mode);
+            break;
+
+        case SCROLL_ON:
+            _display_mode |= ENTRY_MODE_SHIFT_INCREMENT;
+            writeCommand(CMD_ENTRY_MODE_SET | _display_mode);
+            break;
+
+        case SCROLL_OFF:
+            _display_mode &= ~ENTRY_MODE_SHIFT_INCREMENT;
+            writeCommand(CMD_ENTRY_MODE_SET | _display_mode);
+            break;
+    }
+}
 
 void LCD::create(uint8_t location, uint8_t charmap[]) {
-	if (location > 7) return;
-	location &= 0x7;
-	writeCommand(LCD_SET_CGRAM_ADDR | (location << 3));
-	for (int i = 0; i < 8; i++) {
-		writeData(charmap[i]);
-		}
-	}
+    if (location > 7) {
+        return;
+    }
+
+    location &= 0x7;
+    writeCommand(CMD_SET_CGRAM_ADDR | (location << 3));
+
+    for (int i = 0; i < 8; i++) {
+        writeData(charmap[i]);
+    }
+}
 
 int LCD::_putc(int value) {
-	if (value == '\n') {
-		_column = 0;
-		_row++;
-		if (_row >= rows()) {
-			_row = 0;
-			}
-		}
-	else {
-		character(_column, _row, value);
-		_column++;
-		if (_column >= columns()) {
-			_column = 0;
-			_row++;
-			if (_row >= rows()) {
-				_row = 0;
-				}
-			}
-		}
-	return value;
-	}
+    if (value == '\n') {
+        _column = 0;
+        _row++;
+
+        if (_row >= rows()) {
+            _row = 0;
+        }
+
+    } else {
+        character(_column, _row, value);
+        _column++;
+
+        if (_column >= columns()) {
+            _column = 0;
+            _row++;
+
+            if (_row >= rows()) {
+                _row = 0;
+            }
+        }
+    }
+
+    return value;
+}
 
 int LCD::_getc() {
-	return -1;
-	}
+    return -1;
+}
 
-void LCD::writeByte(uint8_t value) {
-	data = value >> 4;
-	wait_us(1); // most instructions take 40us
-	enable = 0;
-	wait_us(1);
-	enable = 1;
-	data = value;
-	wait_us(1);
-	enable = 0;
-	wait_us(1);
-	enable = 1;
-	wait_us(40);
-	}
+uint8_t LCD::getAddress(uint8_t column, uint8_t row) {
+    switch (_type) {
+        case LCD20x4:
+            switch (row) {
+                case 0:
+                    return 0x80 + column;
 
-void LCD::writeCommand(uint8_t command) {
-	reset = 0;
-	writeByte(command);
-	}
+                case 1:
+                    return 0xc0 + column;
 
-void LCD::writeData(uint8_t data) {
-	reset = 1;
-	writeByte(data);
-	}
+                case 2:
+                    return 0x94 + column;
 
-uint8_t LCD::address(uint8_t column, uint8_t row) {
-	switch (type) {
-		case LCD20x4:
-			switch (row) {
-				case 0:
-					return 0x80 + column;
-				case 1:
-					return 0xc0 + column;
-				case 2:
-					return 0x94 + column;
-				case 3:
-					return 0xd4 + column;
-				default:
-					return -1;
-				}
-		case LCD16x2:
-		case LCD20x2:
-		case LCD40x2:
-		default:
-			return 0x80 + (row * 0x40) + column;
-		}
-	}
+                case 3:
+                    return 0xd4 + column;
+
+                default:
+                    return -1;
+            }
+
+        case LCD16x2:
+        case LCD20x2:
+        case LCD40x2:
+        default:
+            return 0x80 + (row * 0x40) + column;
+    }
+}
 
 uint8_t LCD::columns() {
-	switch (type) {
-		case LCD20x4:
-		case LCD20x2:
-		case LCD40x2:
-			return 20;
-		case LCD16x2:
-		default:
-			return 16;
-		}
-	}
+    switch (_type) {
+        case LCD20x4:
+        case LCD20x2:
+        case LCD40x2:
+            return 20;
+
+        case LCD16x2:
+        default:
+            return 16;
+    }
+}
 
 uint8_t LCD::rows() {
-	switch (type) {
-		case LCD20x4:
-			return 4;
-		case LCD16x2:
-		case LCD20x2:
-		case LCD40x2:
-		default:
-			return 2;
-		}
-	}
+    switch (_type) {
+        case LCD20x4:
+            return 4;
+
+        case LCD16x2:
+        case LCD20x2:
+        case LCD40x2:
+        default:
+            return 2;
+    }
+}
+
+void LCD::writeCommand(uint8_t command) {
+    _rs = 0;
+    writeByte(command);
+}
+
+void LCD::writeData(uint8_t data) {
+    _rs = 1;
+    writeByte(data);
+}
+
+void LCD::writeByte(uint8_t value) {
+    _data = value >> 4; // send upper part first
+    pulseEnable();
+    _data = value;
+    pulseEnable();
+}
+
+void LCD::pulseEnable() {
+    _en = 0;
+    wait_us(1);
+    _en = 1;
+    wait_us(1);
+    _en = 0;
+    wait_us(40);
+}

--- a/LCD.cpp
+++ b/LCD.cpp
@@ -25,10 +25,8 @@
 #include "LCD.h"
 #include "mbed.h"
 
-LCD::LCD(PinName rs, PinName en, PinName d4, PinName d5, PinName d6, PinName d7, lcd_type_t type, PinName rw):
-    _rs(rs), _en(en), _data(d4, d5, d6, d7) {
-    _type = type;
-
+LCD::LCD(PinName rs, PinName en, PinName d4, PinName d5, PinName d6, PinName d7, PinName rw, lcd_type_t type):
+    _rs(rs), _en(en), _data(d4, d5, d6, d7), _type(type) {
     if (rw != NC) {
         _rw = new DigitalInOut(rw);
         _rw->write(1);
@@ -74,6 +72,7 @@ void LCD::init() {
     _display_mode = ENTRY_MODE_LEFT | ENTRY_MODE_SHIFT_DECREMENT;
     writeCommand(CMD_ENTRY_MODE_SET | _display_mode);
 }
+
 void LCD::character(uint8_t column, uint8_t row, uint8_t c) {
     uint8_t addr = getAddress(column, row);
     writeCommand(addr);

--- a/LCD.h
+++ b/LCD.h
@@ -76,7 +76,7 @@ class LCD : public Stream {
      * @param rs    Instruction/data control line
      * @param e     Enable line (clock)
      * @param d4-d7 Data lines for using as a 4-bit interface
-     * @param rw    R/W pin (deafult = NC)
+     * @param rw    R/W pin (default = NC)
      * @param type  Sets the panel size/addressing mode (default = LCD16x2)
      */
     LCD(PinName rs, PinName en, PinName d4, PinName d5, PinName d6, PinName d7, PinName rw = NC, lcd_type_t type = LCD16x2);

--- a/LCD.h
+++ b/LCD.h
@@ -39,6 +39,7 @@
  * LCD lcd(p10, p12, p15, p16, p29, p30); // rs, e, d4-d7
  *
  * int main() {
+ *   lcd.init();
  *   lcd.printf("Hello World!\n");
  * }
  * @endcode
@@ -137,13 +138,15 @@ class LCD : public Stream {
     void character(uint8_t column, uint8_t row, uint8_t c);
 
   protected:
-    enum lcd_control_t {
-        CTRL_DISPLAY_ON            = 0x04,
-        CTRL_DISPLAY_OFF           = 0x00,
-        CTRL_CURSOR_ON             = 0x02,
-        CTRL_CURSOR_OFF            = 0x00,
-        CTRL_BLINK_ON              = 0x01,
-        CTRL_BLINK_OFF             = 0x00,
+    enum lcd_command_t {
+        CMD_CLEAR_DISPLAY   = 0x01,
+        CMD_RETURN_HOME     = 0x02,
+        CMD_ENTRY_MODE_SET  = 0x04,
+        CMD_DISPLAY_CONTROL = 0x08,
+        CMD_CURSOR_SHIFT    = 0x10,
+        CMD_FUNCTION_SET    = 0x20,
+        CMD_SET_CGRAM_ADDR  = 0x40,
+        CMD_SET_DDRAM_ADDR  = 0x80,
     };
 
     // Stream implementation functions
@@ -160,25 +163,24 @@ class LCD : public Stream {
     DigitalOut   _en;
     DigitalInOut *_rw;
     BusOut _data;
-    lcd_type_t _type;
+    lcd_type_t _type = LCD16x2;
 
     uint8_t _display_control = CTRL_DISPLAY_OFF | CTRL_CURSOR_OFF | CTRL_BLINK_OFF;
     uint8_t _display_mode = ENTRY_MODE_LEFT | ENTRY_MODE_SHIFT_DECREMENT;
 
-    uint8_t _column;
-    uint8_t _row;
+    uint8_t _column = 0;
+    uint8_t _row = 0;
 
-    enum lcd_command_t {
-        CMD_CLEAR_DISPLAY   = 0x01,
-        CMD_RETURN_HOME     = 0x02,
-        CMD_ENTRY_MODE_SET  = 0x04,
-        CMD_DISPLAY_CONTROL = 0x08,
-        CMD_CURSOR_SHIFT    = 0x10,
-        CMD_FUNCTION_SET    = 0x20,
-        CMD_SET_CGRAM_ADDR  = 0x40,
-        CMD_SET_DDRAM_ADDR  = 0x80,
-    };
   private:
+    enum lcd_control_t {
+        CTRL_DISPLAY_ON            = 0x04,
+        CTRL_DISPLAY_OFF           = 0x00,
+        CTRL_CURSOR_ON             = 0x02,
+        CTRL_CURSOR_OFF            = 0x00,
+        CTRL_BLINK_ON              = 0x01,
+        CTRL_BLINK_OFF             = 0x00,
+    };
+
     enum lcd_function_t {
         FN_8BIT_MODE = 0x10,
         FN_4BIT_MODE = 0x00,

--- a/LCD.h
+++ b/LCD.h
@@ -1,6 +1,7 @@
 /* mbed TextLCD Library, for a 4-bit LCD based on HD44780
  * Copyright (c) 2007-2010, sford, http://mbed.org
  * Copyright (c) 2020, sstaub
+ * Copyright (c) 2021, pilotak
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -27,70 +28,6 @@
 #include "mbed.h"
 #include "Stream.h"
 
-// commands
-#define LCD_CLEAR_DISPLAY         0x01
-#define LCD_RETURN_HOME           0x02
-#define LCD_ENTRY_MODE_SET        0x04
-#define LCD_DISPLAY_CONTROL       0x08
-#define LCD_CURSOR_SHIFT          0x10
-#define LCD_FUNCTION_SET          0x20
-#define LCD_SET_CGRAM_ADDR        0x40
-#define LCD_SET_DDRAM_ADDR        0x80
-// flags for display entry mode
-#define LCD_ENTRY_RIGHT           0x00
-#define LCD_ENTRY_LEFT            0x02
-#define LCD_ENTRY_SHIFT_INCREMENT 0x01
-#define LCD_ENTRY_SHIFT_DECREMENT 0x00
-// flags for display on/off control
-#define LCD_DISPLAY_ON            0x04
-#define LCD_DISPLAY_OFF           0x00
-#define LCD_CURSOR_ON             0x02
-#define LCD_CURSOR_OFF            0x00
-#define LCD_BLINK_ON              0x01
-#define LCD_BLINK_OFF             0x00
-// flags for display/cursor shift
-#define LCD_DISPLAY_MOVE          0x08
-#define LCD_CURSOR_MOVE           0x00
-#define LCD_MOVE_RIGHT            0x04
-#define LCD_MOVE_LEFT             0x00
-// flags for function set
-#define LCD_8BIT_MODE             0x10
-#define LCD_4BIT_MODE             0x00
-#define LCD_2_LINE                0x08
-#define LCD_1_LINE                0x00
-#define LCD_5x10DOTS              0x04
-#define LCD_5x8DOTS               0x00
-
-/**
- * @brief LCD panel format
- * 
- */
-enum lcd_t {
-	LCD16x2,  // 16x2 LCD panel (default)
-	LCD20x2,  // 20x2 LCD panel
-	LCD20x4,  // 20x4 LCD panel
-	LCD40x2   // 40x2 LCD panel
-	};
-
-/**
- * @brief Display modes
- * 
- */
-enum modes_t{
-	DISPLAY_ON,
-	DISPLAY_OFF,
-	CURSOR_ON,
-	CURSOR_OFF,
-	BLINK_ON,
-	BLINK_OFF,
-	SCROLL_LEFT,
-	SCROLL_RIGHT,
-	LEFT_TO_RIGHT,
-	RIGHT_TO_LEFT,
-	SCROLL_ON,
-	SCROLL_OFF,
-	};
-
 /**
  * @brief A TextLCD interface for driving 4-bit HD44780-based LCDs
  *Currently supports 16x2, 20x2 and 20x4 panels
@@ -98,109 +35,175 @@ enum modes_t{
  * @code
  * #include "mbed.h"
  * #include "TextLCD.h"
- * 
+ *
  * LCD lcd(p10, p12, p15, p16, p29, p30); // rs, e, d4-d7
- * 
+ *
  * int main() {
  *   lcd.printf("Hello World!\n");
  * }
  * @endcode
  */
 class LCD : public Stream {
+  public:
+    enum lcd_type_t {
+        LCD16x2,  // 16x2 LCD panel (default)
+        LCD20x2,  // 20x2 LCD panel
+        LCD20x4,  // 20x4 LCD panel
+        LCD40x2   // 40x2 LCD panel
+    };
 
-	public:
+    enum lcd_mode_t {
+        DISPLAY_ON, // Turn the display on
+        DISPLAY_OFF, // Turn the display off
+        CURSOR_ON, // Turns the underline cursor on
+        CURSOR_OFF, // Turns the underline cursor off
+        BLINK_ON, // Turn the blinking cursor on
+        BLINK_OFF, // Turn the blinking cursor off
+        SCROLL_LEFT, // These command scroll the display without changing the RAM
+        SCROLL_RIGHT, // These commands scroll the display without changing the RAM
+        LEFT_TO_RIGHT, // This is for text that flows Left to right
+        RIGHT_TO_LEFT, // This is for text that flows right to lLeft
+        SCROLL_ON, // This will 'right justify' text from the cursor
+        SCROLL_OFF, // This will 'left justify' text from the cursor
+    };
 
-		/** 
-		 * @brief Create a TextLCD interface
-		 *
-		 * @param rs    Instruction/data control line
-		 * @param e     Enable line (clock)
-		 * @param d4-d7 Data lines for using as a 4-bit interface
-		 * @param type  Sets the panel size/addressing mode (default = LCD16x2)
-		 */
-		LCD(PinName rs, PinName en, PinName d4, PinName d5, PinName d6, PinName d7, lcd_t type = LCD16x2);
+    /**
+     * @brief Create a TextLCD interface
+     *
+     * @param rs    Instruction/data control line
+     * @param e     Enable line (clock)
+     * @param d4-d7 Data lines for using as a 4-bit interface
+     * @param type  Sets the panel size/addressing mode (default = LCD16x2)
+     * @param rw    R/W pin
+     */
+    LCD(PinName rs, PinName en, PinName d4, PinName d5, PinName d6, PinName d7, lcd_type_t type = LCD16x2, PinName rw = NC);
 
-		/**
-		 * @brief Clear the screen and locate to 0,0
-		 * 
-		 */
-		void cls();
+    /**
+     * @brief Destructor
+     *
+     */
+    ~LCD();
 
-		/**
-		 * @brief Locate to a screen column and row
-		 *
-		 * @param column  The horizontal position from the left, indexed from 0
-		 * @param row     The vertical position from the top, indexed from 0
-		 */
-		void locate(uint8_t column, uint8_t row);
+    /**
+     * @brief Initialize the display
+     *
+     */
+    void init();
 
-		/**
-		 * @brief Set cursor position to zero
-		 * 
-		 */
-		void home();
+    /**
+     * @brief Clear the screen and locate to 0,0
+     *
+     */
+    void cls();
 
-		/**
-		 * @brief Set display modes
-		 * 
-		 * @param mode 
-		 * - DISPLAY_ON Turn the display on
-		 * - DISPLAY_OFF Turn the display off
-		 * - CURSOR_ON Turns the underline cursor on
-		 * - CURSOR_OFF Turns the underline cursor off
-		 * - BLINK_ON Turn the blinking cursor on
-		 * - BLINK_OFF Turn the blinking cursor off
-		 * - SCROLL_LEFT These command scroll the display without changing the RAM
-		 * - SCROLL_RIGHT These commands scroll the display without changing the RAM
-		 * - LEFT_TO_RIGHT This is for text that flows Left to Right
-		 * - RIGHT_TO_LEFT This is for text that flows Right to Left
-		 * - AUTOSCROLL_ON This will 'right justify' text from the cursor
-		 * - AUTOSCROLL_OFF This will 'left justify' text from the cursor
-		 * 
-		 */
-		void display(modes_t mode);
+    /**
+     * @brief Locate to a screen column and row
+     *
+     * @param column  The horizontal position from the left, indexed from 0
+     * @param row     The vertical position from the top, indexed from 0
+     */
+    void locate(uint8_t column, uint8_t row);
 
-		/**
-		 * @brief Create a user defined char object 
-		 * Allows us to fill the first 8 CGRAM locations
-		 * with custom characters
-		 * 
-		 * @param location 
-		 * @param charmap 
-		 */
-		void create(uint8_t location, uint8_t charmap[]);
+    /**
+     * @brief Set cursor position to zero
+     *
+     */
+    void home();
 
-		/**
-		 * @brief Writes a single char to a given position, usefull for UDC
-		 * 
-		 * @param column 
-		 * @param row 
-		 * @param c charachter
-		 */
-		void character(uint8_t column, uint8_t row, uint8_t c);
+    /**
+     * @brief Set display modes
+     *
+     * @param mode
+     */
+    void display(lcd_mode_t mode);
 
-	protected:
+    /**
+     * @brief Create a user defined char object
+     * Allows us to fill the first 8 CGRAM locations
+     * with custom characters
+     *
+     * @param location
+     * @param charmap
+     */
+    void create(uint8_t location, uint8_t charmap[]);
 
-		// Stream implementation functions
-		virtual int _putc(int value);
-		virtual int _getc();
-		
-		uint8_t rows();
-		uint8_t columns();
-		uint8_t address(uint8_t column, uint8_t row);
-		void writeByte(uint8_t value);
-		void writeCommand(uint8_t command);
-		void writeData(uint8_t data);
+    /**
+     * @brief Writes a single char to a given position, usefull for UDC
+     *
+     * @param column
+     * @param row
+     * @param c character
+     */
+    void character(uint8_t column, uint8_t row, uint8_t c);
 
-		DigitalOut reset, enable;
-		BusOut data;
-		lcd_t type;
+  protected:
+    enum lcd_control_t {
+        CTRL_DISPLAY_ON            = 0x04,
+        CTRL_DISPLAY_OFF           = 0x00,
+        CTRL_CURSOR_ON             = 0x02,
+        CTRL_CURSOR_OFF            = 0x00,
+        CTRL_BLINK_ON              = 0x01,
+        CTRL_BLINK_OFF             = 0x00,
+    };
 
-		uint8_t displaycontrol;
-		uint8_t displaymode;
+    // Stream implementation functions
+    virtual int _putc(int value);
+    virtual int _getc();
 
-		uint8_t _column;
-		uint8_t _row;
-	};
+    uint8_t rows();
+    uint8_t columns();
+    void writeByte(uint8_t value);
+    void writeCommand(uint8_t command);
+    void writeData(uint8_t data);
+
+    DigitalOut   _rs;
+    DigitalOut   _en;
+    DigitalInOut *_rw;
+    BusOut _data;
+    lcd_type_t _type;
+
+    uint8_t _display_control = CTRL_DISPLAY_OFF | CTRL_CURSOR_OFF | CTRL_BLINK_OFF;
+    uint8_t _display_mode = ENTRY_MODE_LEFT | ENTRY_MODE_SHIFT_DECREMENT;
+
+    uint8_t _column;
+    uint8_t _row;
+
+    enum lcd_command_t {
+        CMD_CLEAR_DISPLAY   = 0x01,
+        CMD_RETURN_HOME     = 0x02,
+        CMD_ENTRY_MODE_SET  = 0x04,
+        CMD_DISPLAY_CONTROL = 0x08,
+        CMD_CURSOR_SHIFT    = 0x10,
+        CMD_FUNCTION_SET    = 0x20,
+        CMD_SET_CGRAM_ADDR  = 0x40,
+        CMD_SET_DDRAM_ADDR  = 0x80,
+    };
+  private:
+    enum lcd_function_t {
+        FN_8BIT_MODE = 0x10,
+        FN_4BIT_MODE = 0x00,
+        FN_2LINE     = 0x08,
+        FN_1LINE     = 0x00,
+        FN_5x10DOTS  = 0x04,
+        FN_5x8DOTS   = 0x00,
+    };
+
+    enum lcd_entry_mode_t {
+        ENTRY_MODE_RIGHT           = 0x00,
+        ENTRY_MODE_LEFT            = 0x02,
+        ENTRY_MODE_SHIFT_INCREMENT = 0x01,
+        ENTRY_MODE_SHIFT_DECREMENT = 0x00,
+    };
+
+    enum lcd_shift_t {
+        DISPLAY_MOVE = 0x08,
+        CURSOR_MOVE  = 0x00,
+        MOVE_RIGHT   = 0x04,
+        MOVE_LEFT    = 0x00,
+    };
+
+    void pulseEnable();
+    uint8_t getAddress(uint8_t column, uint8_t row);
+};
 
 #endif

--- a/LCD.h
+++ b/LCD.h
@@ -200,9 +200,9 @@ class LCD : public Stream {
         MOVE_LEFT    = 0x00,
     };
 
-    DigitalOut   _rs;
-    DigitalOut   _en;
-    DigitalInOut *_rw;
+    DigitalOut _rs;
+    DigitalOut _en;
+    DigitalOut *_rw;
     BusOut _data;
     const lcd_type_t _type = LCD16x2;
 

--- a/LCD.h
+++ b/LCD.h
@@ -74,10 +74,10 @@ class LCD : public Stream {
      * @param rs    Instruction/data control line
      * @param e     Enable line (clock)
      * @param d4-d7 Data lines for using as a 4-bit interface
+     * @param rw    R/W pin (deafult = NC)
      * @param type  Sets the panel size/addressing mode (default = LCD16x2)
-     * @param rw    R/W pin
      */
-    LCD(PinName rs, PinName en, PinName d4, PinName d5, PinName d6, PinName d7, lcd_type_t type = LCD16x2, PinName rw = NC);
+    LCD(PinName rs, PinName en, PinName d4, PinName d5, PinName d6, PinName d7, PinName rw = NC, lcd_type_t type = LCD16x2);
 
     /**
      * @brief Destructor

--- a/LCD.h
+++ b/LCD.h
@@ -30,7 +30,7 @@
 
 /**
  * @brief A TextLCD interface for driving 4-bit HD44780-based LCDs
- *Currently supports 16x2, 20x2 and 20x4 panels
+ *Currently supports 8x2, 16x2, 20x2 and 20x4 panels
  *
  * @code
  * #include "mbed.h"
@@ -40,14 +40,16 @@
  *
  * int main() {
  *   lcd.init();
- *   lcd.printf("Hello World!\n");
+ *   lcd.display(LCD::DISPLAY_ON)
+ *   lcd.printf("Hello World!");
  * }
  * @endcode
  */
 class LCD : public Stream {
   public:
     enum lcd_type_t {
-        LCD16x2,  // 16x2 LCD panel (default)
+        LCD8x2,   // 8x2 LCD panel
+        LCD16x2,  // 16x2 LCD panel
         LCD20x2,  // 20x2 LCD panel
         LCD20x4,  // 20x4 LCD panel
         LCD40x2   // 40x2 LCD panel
@@ -63,7 +65,7 @@ class LCD : public Stream {
         SCROLL_LEFT, // These command scroll the display without changing the RAM
         SCROLL_RIGHT, // These commands scroll the display without changing the RAM
         LEFT_TO_RIGHT, // This is for text that flows Left to right
-        RIGHT_TO_LEFT, // This is for text that flows right to lLeft
+        RIGHT_TO_LEFT, // This is for text that flows right to left
         SCROLL_ON, // This will 'right justify' text from the cursor
         SCROLL_OFF, // This will 'left justify' text from the cursor
     };
@@ -120,8 +122,7 @@ class LCD : public Stream {
 
     /**
      * @brief Create a user defined char object
-     * Allows us to fill the first 8 CGRAM locations
-     * with custom characters
+     * Allows us to fill the first 8 CGRAM locations with custom characters
      *
      * @param location
      * @param charmap
@@ -137,6 +138,20 @@ class LCD : public Stream {
      */
     void character(uint8_t column, uint8_t row, uint8_t c);
 
+    /**
+     * @brief Get number of rows
+     *
+     * @return row count
+     */
+    uint8_t rows();
+
+    /**
+     * @brief Get number of columns
+     *
+     * @return column count
+     */
+    uint8_t columns();
+
   protected:
     enum lcd_command_t {
         CMD_CLEAR_DISPLAY   = 0x01,
@@ -149,27 +164,8 @@ class LCD : public Stream {
         CMD_SET_DDRAM_ADDR  = 0x80,
     };
 
-    // Stream implementation functions
-    virtual int _putc(int value);
-    virtual int _getc();
-
-    uint8_t rows();
-    uint8_t columns();
-    void writeByte(uint8_t value);
     void writeCommand(uint8_t command);
     void writeData(uint8_t data);
-
-    DigitalOut   _rs;
-    DigitalOut   _en;
-    DigitalInOut *_rw;
-    BusOut _data;
-    lcd_type_t _type = LCD16x2;
-
-    uint8_t _display_control = CTRL_DISPLAY_OFF | CTRL_CURSOR_OFF | CTRL_BLINK_OFF;
-    uint8_t _display_mode = ENTRY_MODE_LEFT | ENTRY_MODE_SHIFT_DECREMENT;
-
-    uint8_t _column = 0;
-    uint8_t _row = 0;
 
   private:
     enum lcd_control_t {
@@ -204,6 +200,23 @@ class LCD : public Stream {
         MOVE_LEFT    = 0x00,
     };
 
+    DigitalOut   _rs;
+    DigitalOut   _en;
+    DigitalInOut *_rw;
+    BusOut _data;
+    const lcd_type_t _type = LCD16x2;
+
+    uint8_t _display_control = CTRL_DISPLAY_OFF | CTRL_CURSOR_OFF | CTRL_BLINK_OFF;
+    uint8_t _display_mode = ENTRY_MODE_LEFT | ENTRY_MODE_SHIFT_DECREMENT;
+
+    uint8_t _column = 0;
+    uint8_t _row = 0;
+
+    // Stream implementation functions
+    int _putc(int value);
+    int _getc();
+
+    void writeByte(uint8_t value);
     void pulseEnable();
     uint8_t getAddress(uint8_t column, uint8_t row);
 };

--- a/README.md
+++ b/README.md
@@ -61,8 +61,9 @@ uint8_t leftArrow[8] = {
 LCD lcd(D0, D1, D2, D3, D4, D5, LCD::LCD16x2); // rs, en, d4-d7, LCD type
 
 int main() {
-    ThisThread::sleep_for(50ms); // it takes a long time after power up
+    ThisThread::sleep_for(50ms); // wait for a long time after power up
     lcd.init();
+    lcd.display(LCD::DISPLAY_ON);
 
     lcd.create(0, downArrow);
     lcd.create(1, upArrow);

--- a/README.md
+++ b/README.md
@@ -63,7 +63,8 @@ uint8_t leftArrow[8] = {
 LCD lcd(D0, D1, D2, D3, D4, D5, LCD16x2); // rs, en, d4-d7, LCD type
 
 int main() {
-	
+	lcd.init();
+
 	lcd.create(0, downArrow);
 	lcd.create(1, upArrow);
 	lcd.create(2, rightArrow);

--- a/README.md
+++ b/README.md
@@ -1,130 +1,129 @@
-# mbed6 LCD library for HD47780
+# Mbed LCD library for HD47780
+[![Framework Badge mbed](https://img.shields.io/badge/framework-mbed-008fbe.svg)](https://os.mbed.com/)
 
-This library is for the HD47780 LCDs with 4-bit interface for use with mbed 6
+This library is for the HD47780 LCDs with 4-bit interface for use with mbed-os 6
 
 
 ## Installation
-
-1. "Download":https://github.com/sstaub/mbedLCD/archive/master.zip the Master branch from GitHub.
+1. "Download":https://github.com/sstaub/mbedLCD/archive/master.zip the Master branch from GitHub or using mbed CLI `mbed add https://github.com/sstaub/mbedLCD`
 2. Unzip and modify the folder name to "mbedLCD"
-3. Move the modified folder on your Library folder.
+3. Move the modified folder on your Library folder
 
 
 ## Example
 Here is a simple example which shows the capabilities of the display
 
 ```cpp
-// example for mbed6 LCD library
-
 #include "mbed.h"
 #include "LCD.h"
 
 // special chars
-uint8_t upArrow[8] = {  
-	0b00100,
-	0b01010,
-	0b10001,
-	0b00100,
-	0b00100,
-	0b00100,
-	0b00000,
-	};
+uint8_t upArrow[8] = {
+    0b00100,
+    0b01010,
+    0b10001,
+    0b00100,
+    0b00100,
+    0b00100,
+    0b00000,
+};
 
 uint8_t downArrow[8] = {
-	0b00000,
-	0b00100,
-	0b00100,
-	0b00100,
-	0b10001,
-	0b01010,
-	0b00100,
-	};
+    0b00000,
+    0b00100,
+    0b00100,
+    0b00100,
+    0b10001,
+    0b01010,
+    0b00100,
+};
 
 uint8_t rightArrow[8] = {
-	0b00000,
-	0b00100,
-	0b00010,
-	0b11001,
-	0b00010,
-	0b00100,
-	0b00000,
-	};
+    0b00000,
+    0b00100,
+    0b00010,
+    0b11001,
+    0b00010,
+    0b00100,
+    0b00000,
+};
 
 uint8_t leftArrow[8] = {
-	0b00000,
-	0b00100,
-	0b01000,
-	0b10011,
-	0b01000,
-	0b00100,
-	0b00000,
-	};
+    0b00000,
+    0b00100,
+    0b01000,
+    0b10011,
+    0b01000,
+    0b00100,
+    0b00000,
+};
 
-LCD lcd(D0, D1, D2, D3, D4, D5, LCD16x2); // rs, en, d4-d7, LCD type
+LCD lcd(D0, D1, D2, D3, D4, D5, LCD::LCD16x2); // rs, en, d4-d7, LCD type
 
 int main() {
-	lcd.init();
+    ThisThread::sleep_for(50ms); // it takes a long time after power up
+    lcd.init();
 
-	lcd.create(0, downArrow);
-	lcd.create(1, upArrow);
-	lcd.create(2, rightArrow);
-	lcd.create(3, leftArrow);
-	
-	lcd.cls();
-	lcd.locate(0, 0);
-	lcd.printf("Hello World!\n");
-	lcd.character(0, 1, 0);
-	lcd.character(3, 1, 1);
-	lcd.character(5, 1, 2);
-	lcd.character(7, 1, 3);
+    lcd.create(0, downArrow);
+    lcd.create(1, upArrow);
+    lcd.create(2, rightArrow);
+    lcd.create(3, leftArrow);
 
-	ThisThread::sleep_for(2s);
-	lcd.cls();
-	lcd.locate(0, 0);
-	lcd.printf("Hello World!\n");
+    lcd.cls();
+    lcd.locate(0, 0);
+    lcd.printf("Hello World!\n");
+    lcd.character(0, 1, 0);
+    lcd.character(3, 1, 1);
+    lcd.character(5, 1, 2);
+    lcd.character(7, 1, 3);
 
-	ThisThread::sleep_for(2s);
-	lcd.display(DISPLAY_OFF);
-	ThisThread::sleep_for(2s);
-	lcd.display(DISPLAY_ON);
-	ThisThread::sleep_for(2s);
-	lcd.display(CURSOR_ON);
-	ThisThread::sleep_for(2s);
-	lcd.display(BLINK_ON);
-	ThisThread::sleep_for(2s);
-	lcd.display(BLINK_OFF);
-	ThisThread::sleep_for(2s);
-	lcd.display(CURSOR_OFF);
+    ThisThread::sleep_for(2s);
+    lcd.cls();
+    lcd.locate(0, 0);
+    lcd.printf("Hello World!\n");
 
-	while(1) {
-		for (uint8_t pos = 0; pos < 13; pos++) {
-    	// scroll one position to left
-    	lcd.display(SCROLL_LEFT);
-    	// step time
-    	ThisThread::sleep_for(500ms);
-  		}
+    ThisThread::sleep_for(2s);
+    lcd.display(LCD::DISPLAY_OFF);
+    ThisThread::sleep_for(2s);
+    lcd.display(LCD::DISPLAY_ON);
+    ThisThread::sleep_for(2s);
+    lcd.display(LCD::CURSOR_ON);
+    ThisThread::sleep_for(2s);
+    lcd.display(LCD::BLINK_ON);
+    ThisThread::sleep_for(2s);
+    lcd.display(LCD::BLINK_OFF);
+    ThisThread::sleep_for(2s);
+    lcd.display(LCD::CURSOR_OFF);
 
-  	// scroll 29 positions (string length + display length) to the right
-  	// to move it offscreen right
-  	for (uint8_t pos = 0; pos < 29; pos++) {
-  	  // scroll one position to right
-  	  lcd.display(SCROLL_RIGHT);
-  	  // step time
-  	  ThisThread::sleep_for(500ms);
-  		}
+    while (1) {
+        for (uint8_t pos = 0; pos < 13; pos++) {
+            // scroll one position to left
+            lcd.display(LCD::SCROLL_LEFT);
+            // step time
+            ThisThread::sleep_for(500ms);
+        }
 
-  	// scroll 16 positions (display length + string length) to the left
-  	// to move it back to center
-  	for (uint8_t pos = 0; pos < 16; pos++) {
-  	  // scroll one position to left
-  	  lcd.display(SCROLL_LEFT);
-  	  // step time
-  	  ThisThread::sleep_for(500ms);
-  		}
- 
-		ThisThread::sleep_for(1s);
-		}
-	}
+        // scroll 29 positions (string length + display length) to the right
+        // to move it offscreen right
+        for (uint8_t pos = 0; pos < 29; pos++) {
+            // scroll one position to right
+            lcd.display(LCD::SCROLL_RIGHT);
+            // step time
+            ThisThread::sleep_for(500ms);
+        }
+
+        // scroll 16 positions (display length + string length) to the left
+        // to move it back to center
+        for (uint8_t pos = 0; pos < 16; pos++) {
+            // scroll one position to left
+            lcd.display(LCD::SCROLL_LEFT);
+            // step time
+            ThisThread::sleep_for(500ms);
+        }
+
+        ThisThread::sleep_for(1s);
+    }
+}
 ```
 
 # Documentation
@@ -140,7 +139,7 @@ following display types are supported
 create a LCD object
 
 ```cpp
-LCD::LCD(PinName rs, PinName en, PinName d4, PinName d5, PinName d6, PinName d7, lcd_t type = LCD16x2)
+LCD::LCD(PinName rs, PinName en, PinName d4, PinName d5, PinName d6, PinName d7, lcd_type_t type = LCD16x2, PinName rw = NC)
 ```
 
 create a LCD object
@@ -149,11 +148,12 @@ create a LCD object
 - **en** enable pin
 - **d4** thru **d7** data pins
 - **type** display type
+- **rw** r/w pin
 
 **Example**
 
 ```cpp
-LCD lcd(D0, D1, D2, D3, D4, D5, LCD16x2); // rs, en, d4-d7, LCD type
+LCD lcd(D0, D1, D2, D3, D4, D5, LCD::LCD16x2, D7); // rs, en, d4-d7, LCD type, rw
 ``
 
 ## Class Functions
@@ -174,7 +174,7 @@ lcd.cls();
 ### Display Modes
 
 ```cpp
-void LCD::display(modes_t mode)
+void LCD::display(lcd_mode_t mode)
 ```
 
 set the modes of the display
@@ -189,13 +189,13 @@ set the modes of the display
 - SCROLL_RIGHT these command scroll the display without changing the RAM
 - LEFT_TO_RIGHT this is for text that flows Left to Right
 - RIGHT_TO_LEFT this is for text that flows Right to Left
-- AUTOSCROLL_ON this will 'right justify' text from the cursor
-- AUTOSCROLL_OFF this will 'left justify' text from the cursor
+- SCROLL_ON this will 'right justify' text from the cursor
+- SCROLL_OFF this will 'left justify' text from the cursor
 
 **Example**
 
 ```cpp
-lcd.display(CURSOR_ON);
+lcd.display(LCD::CURSOR_ON);
 ```
 
 ### Cursor Location


### PR DESCRIPTION
Hi i did a little bit clean up and added a R/W pin.

The main differences:
- you need to call `init()` yourself - this is because you might be using a voltage level translator with OE pin which you need to assert first before initializing the lib itself
- changed macros to enum names, they are only accessible with `LCD::` prefix, this is useful if you have other variables in the code named the same so you avoid collisions
- clear & home command needed a 3ms delay instead of 2ms othewise there was a problem during power-on

If you do not like it feel free to close this PR. I also plan to refactor the I2C version so they are consistent and also create an OLED version of 16x2